### PR TITLE
Fix documentation errors and spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ SinaTools
 ======================
 Open Source Toolkit for Arabic NLP and NLU developed by [SinaLab](http://sina.birzeit.edu/) at Birzeit University. SinaTools is available through Python APIs, command lines, colabs, and online demos.
 
-See the full list of [Available Packages](https://sina.birzeit.edu/sinatools/), which include: (1) [Morphology Tagging](https://sina.birzeit.edu/sinatools/index.html#morph), (2) [Named Entity Recognition (NER)](https://sina.birzeit.edu/sinatools/index.html#ner), (3) [Word Sense Disambiguation (WSD)](https://sina.birzeit.edu/sinatools/index.html#wsd), (4) [Semantic Relatedness](https://sina.birzeit.edu/sinatools/index.html#sr), (5) [Synonymy Extraction and Evaluation](https://sina.birzeit.edu/sinatools/index.html#se), (6) [Relation Extraction](https://sina.birzeit.edu/sinatools/index.html#re), (7) [Utilities](https://sina.birzeit.edu/sinatools/index.html#u) (diacritic-based word matching, Jaccard similarly, parser, tokenizers, corpora processing, transliteration, etc).
+See the full list of [Available Packages](https://sina.birzeit.edu/sinatools/), which include: (1) [Morphology Tagging](https://sina.birzeit.edu/sinatools/index.html#morph), (2) [Named Entity Recognition (NER)](https://sina.birzeit.edu/sinatools/index.html#ner), (3) [Word Sense Disambiguation (WSD)](https://sina.birzeit.edu/sinatools/index.html#wsd), (4) [Semantic Relatedness](https://sina.birzeit.edu/sinatools/index.html#sr), (5) [Synonymy Extraction and Evaluation](https://sina.birzeit.edu/sinatools/index.html#se), (6) [Relation Extraction](https://sina.birzeit.edu/sinatools/index.html#re), (7) [Utilities](https://sina.birzeit.edu/sinatools/index.html#u) (diacritic-based word matching, Jaccard similarity, parser, tokenizers, corpora processing, transliteration, etc).
 
 See [Demo Pages](https://sina.birzeit.edu/sinatools/).
 
@@ -24,7 +24,7 @@ Some modules in SinaTools require some data files and fine-tuned models to be do
 
 Documentation
 --------
-For information, please refer to the [main page](https://sina.birzeit.edu/sinatools) or the [online domuementation](https://sina.birzeit.edu/sinatools/documentation). 
+For information, please refer to the [main page](https://sina.birzeit.edu/sinatools) or the [online documentation](https://sina.birzeit.edu/sinatools/documentation). 
 
 Citation
 -------

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ SinaTools
 ======================
 Open Source Toolkit for Arabic NLP and NLU developed by [SinaLab](http://sina.birzeit.edu/) at Birzeit University. SinaTools is available through Python APIs, command lines, colabs, and online demos.
 
-See the full list of [Available Packages](https://sina.birzeit.edu/sinatools/), which include: (1) [Morphology Tagging](https://sina.birzeit.edu/sinatools/index.html#morph), (2) [Named Entity Recognition (NER)](https://sina.birzeit.edu/sinatools/index.html#ner), (3) [Word Sense Disambiguation (WSD)](https://sina.birzeit.edu/sinatools/index.html#wsd), (4) [Semantic Relatedness](https://sina.birzeit.edu/sinatools/index.html#sr), (5) [Synonymy Extraction and Evaluation](https://sina.birzeit.edu/sinatools/index.html#se), (6) [Relation Extraction](https://sina.birzeit.edu/sinatools/index.html#re), (7) [Utilities](https://sina.birzeit.edu/sinatools/index.html#u) (diacritic-based word matching, Jaccard similarly, parser, tokenizers, corpora processing, transliteration, etc).
+See the full list of [Available Packages](https://sina.birzeit.edu/sinatools/), which include: (1) [Morphology Tagging](https://sina.birzeit.edu/sinatools/index.html#morph), (2) [Named Entity Recognition (NER)](https://sina.birzeit.edu/sinatools/index.html#ner), (3) [Word Sense Disambiguation (WSD)](https://sina.birzeit.edu/sinatools/index.html#wsd), (4) [Semantic Relatedness](https://sina.birzeit.edu/sinatools/index.html#sr), (5) [Synonymy Extraction and Evaluation](https://sina.birzeit.edu/sinatools/index.html#se), (6) [Relation Extraction](https://sina.birzeit.edu/sinatools/index.html#re), (7) [Utilities](https://sina.birzeit.edu/sinatools/index.html#u) (diacritic-based word matching, Jaccard similarity, parser, tokenizers, corpora processing, transliteration, etc).
 
 See [Demo Pages](https://sina.birzeit.edu/sinatools/).
 
@@ -24,7 +24,7 @@ Some modules in SinaTools require some data files and fine-tuned models to be do
 
 Documentation
 --------
-For information, please refer to the [main page](https://sina.birzeit.edu/sinatools) or the [online domuementation](https://sina.birzeit.edu/sinatools/documentation). 
+For information, please refer to the [main page](https://sina.birzeit.edu/sinatools) or the [online documentation](https://sina.birzeit.edu/sinatools/documentation). 
 
 Citation
 -------

--- a/build/lib/sinatools/utils/text_dublication_detector.py
+++ b/build/lib/sinatools/utils/text_dublication_detector.py
@@ -34,7 +34,7 @@ def removal(csv_file, columnName, finalFileName, deletedFileName, similarityThre
     .. code-block:: python
     
         from sinatools.utils.text_dublication_detector import removal
-        removal("/path/to/csv/file1", sentences, "/path/to/csv/file2", 0.8)
+        removal("/path/to/csv/file1", "sentences", "/path/to/final/file", "/path/to/deleted/file", 0.8)
     """
 
     # Read CSV file

--- a/sinatools/utils/text_dublication_detector.py
+++ b/sinatools/utils/text_dublication_detector.py
@@ -34,7 +34,7 @@ def removal(csv_file, columnName, finalFileName, deletedFileName, similarityThre
     .. code-block:: python
     
         from sinatools.utils.text_dublication_detector import removal
-        removal("/path/to/csv/file1", sentences, "/path/to/csv/file2", 0.8)
+        removal("/path/to/csv/file1", "sentences", "/path/to/final/file", "/path/to/deleted/file", 0.8)
     """
 
     # Read CSV file


### PR DESCRIPTION
The function usage example for `text_dublication_detector.py` was missing the deleted filename parameter and the column parameter `sentences` was not a string. The current fix corrects this and makes the usage example much more clearer.

Minor spelling mistakes in the project README files have also been corrected.

Another small documentation problem was found in `parser.py:69`. It is a syntax warning for the lone `\` character which Python sees as the beginning of an escape sequence. However, I have not corrected it assuming you guys must've seen that warning many times and do not care.