### PR TITLE
Variable `output_string` initialized earlier

### DIFF
--- a/build/lib/sinatools/utils/parser.py
+++ b/build/lib/sinatools/utils/parser.py
@@ -93,6 +93,7 @@ def remove_punctuation(text):
         يَا أَيُّهَا الَّذِينَ آمَنُوا لِيَسْتَأْذِنْكُمُ  
 
     """
+    output_string = text
     try:
         if text:
             punctuation_marks = [r'[\u0021-\u002F]+', r'[U+060C]+', r'[\u003A-\u0040]+',
@@ -100,7 +101,6 @@ def remove_punctuation(text):
                                  r'[\u061B]+', r'[\u061E]+', r'[\u061F]+', r'[\u0640]+',
                                  r'[\u0653]+', r'[\u065C]+', r'[\u066C]+', r'[\u066A]+',
                                  r'["}"]+', r'["{"]+']
-            output_string = text
             for punctuation in punctuation_marks:
                 output_string = re.sub(punctuation, '', output_string)
     except:

--- a/sinatools/utils/parser.py
+++ b/sinatools/utils/parser.py
@@ -93,6 +93,7 @@ def remove_punctuation(text):
         يَا أَيُّهَا الَّذِينَ آمَنُوا لِيَسْتَأْذِنْكُمُ  
 
     """
+    output_string = text
     try:
         if text:
             punctuation_marks = [r'[\u0021-\u002F]+', r'[U+060C]+', r'[\u003A-\u0040]+',
@@ -100,7 +101,6 @@ def remove_punctuation(text):
                                  r'[\u061B]+', r'[\u061E]+', r'[\u061F]+', r'[\u0640]+',
                                  r'[\u0653]+', r'[\u065C]+', r'[\u066C]+', r'[\u066A]+',
                                  r'["}"]+', r'["{"]+']
-            output_string = text
             for punctuation in punctuation_marks:
                 output_string = re.sub(punctuation, '', output_string)
     except:


### PR DESCRIPTION
Certain characters can find themselves identified as single words in parsed Arabic corpus data, such as "ـ" (Unicode point 0640). If this "word" is then passed to the SinaTools utilities it may be passed to `arStrip` and subsequently the `remove_punctuation` function. Such an argument will then raise `UnboundLocalError` in `remove_punctuation` (since the argument passed to `text` is `''`):

```python
UnboundLocalError: cannot access local variable 'output_string' where it is not associated with a value
```

A simple fix is to just move the initialization of `output_string` right above the `try` block. This seems very sensible, actually since a _fail silently_ approach works well for this function, leaving the returned value as a blank that was only processed by `arStrip`.